### PR TITLE
Fix deploy workflow lacking checkout instruction

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,8 @@ jobs:
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Update image tag
         env:
           ECR_URL: ${{ secrets.ECR_URL }}


### PR DESCRIPTION
In previous PR #5 the job was split into 2 separate steps, but in doing so, the second step doesn't have the local files anymore, as only the first step does the checkout.

This adds the missing checkout to the new `deploy-dev` step too.