### PR TITLE
Extend workflow to trigger deploy to production

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,3 +57,33 @@ jobs:
       - name: Apply manifest files
         run: |
           kubectl -n ${KUBE_NAMESPACE} apply -f kubectl_deploy/development
+
+  deploy-prod:
+    runs-on: ubuntu-latest
+    needs: deploy-dev
+    environment: production
+
+    env:
+      KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update image tag
+        env:
+          ECR_URL: ${{ secrets.ECR_URL }}
+        run: export IMAGE_TAG=${{ github.sha }} && cat kubectl_deploy/production/deployment.tpl | envsubst > kubectl_deploy/production/deployment.yaml
+      - name: Authenticate to the cluster
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_PROD_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_PROD_TOKEN }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_PROD_CLUSTER }}
+        run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+      - name: Apply manifest files
+        run: |
+          kubectl -n ${KUBE_NAMESPACE} apply -f kubectl_deploy/production

--- a/kubectl_deploy/production/deployment.tpl
+++ b/kubectl_deploy/production/deployment.tpl
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: courts-local-scorecard-dev
+  name: courts-local-scorecard-prod
 spec:
   replicas: 2
   revisionHistoryLimit: 5
@@ -12,11 +12,11 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: courts-local-scorecard-dev
+      app: courts-local-scorecard-prod
   template:
     metadata:
       labels:
-        app: courts-local-scorecard-dev
+        app: courts-local-scorecard-prod
     spec:
       containers:
       - name: local-scorecard

--- a/kubectl_deploy/production/ingress.yaml
+++ b/kubectl_deploy/production/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: courts-local-scorecard-prod-ingress
+  namespace: courts-local-scorecard-prod
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: courts-local-scorecard-prod-ingress-courts-local-scorecard-prod-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+spec:
+  tls:
+  - hosts:
+    - courts-local-scorecard-prod.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: courts-local-scorecard-prod.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: local-scorecard-service
+            port:
+              number: 8080

--- a/kubectl_deploy/production/secret.yaml
+++ b/kubectl_deploy/production/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+data:
+  auth: bG9jYWwtc2NvcmVjYXJkLXVzZXI6JGFwcjEkLzJ1SXRsS3IkN2IubVRCLjJ1RjNvWXdScE9KdExHMA==

--- a/kubectl_deploy/production/service.yaml
+++ b/kubectl_deploy/production/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-scorecard-service
+  labels:
+    app: courts-local-scorecard-prod
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+  selector:
+    app: courts-local-scorecard-prod


### PR DESCRIPTION
Essentially duplicating the existing `development` manifest files into their own `production` directory (changing their metadata and labels to match prod namespace).

Add new step to the workflow to deploy to prod, after approval.

Deployment manifest updated to have 2 replicas and rolling update strategy (for zero downtime deploys).