### PR TITLE
Cleanup JS references

### DIFF
--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -108,10 +108,6 @@
     </div>
 </footer>
 
-<script src="js/govuk.js"></script>
-<script>
-    window.GOVUKFrontend.initAll();
-</script>
 </body>
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -148,10 +148,6 @@
     </div>
 </footer>
 
-<script src="js/govuk.js"></script>
-<script>
-    window.GOVUKFrontend.initAll();
-</script>
 </body>
 
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,7 +14,6 @@ const mix_ = require('laravel-mix');
 mix_.copy('src/index.html', 'dist/index.html')
     .copy('src/accessibility.html', 'dist/accessibility.html')
     .copy('src/judiciary-icon.png', 'dist/judiciary-icon.png')
-    .copy('node_modules/govuk-frontend/govuk/all.js', 'dist/assets/js/govuk.js')
     .copy('node_modules/govuk-frontend/govuk/assets/images', 'dist/assets/images')
     .copy('node_modules/govuk-frontend/govuk/assets/fonts', 'dist/assets/fonts')
     .sass('src/app.scss', 'dist/assets/css');


### PR DESCRIPTION
The service is not using currently any GOV.UK frontend javascript.

It is easy to add it again if required.