### PR TITLE
Add k8s probes to deployment manifests

### DIFF
--- a/kubectl_deploy/development/deployment.tpl
+++ b/kubectl_deploy/development/deployment.tpl
@@ -23,3 +23,15 @@ spec:
         image: ${ECR_URL}:${IMAGE_TAG}
         ports:
         - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 15

--- a/kubectl_deploy/production/deployment.tpl
+++ b/kubectl_deploy/production/deployment.tpl
@@ -23,3 +23,15 @@ spec:
         image: ${ECR_URL}:${IMAGE_TAG}
         ports:
         - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 15


### PR DESCRIPTION
Add the usual, readinessProbe and livenessProbe with sensible delay/period values for this app.

If we find issues with these values we can tweak them as we get a feeling of how this perform.