### PR TITLE
Apply the GOV.UK link styles globally

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,3 +1,5 @@
+$govuk-new-link-styles: true;
+$govuk-global-styles: true;
 
 @import "node_modules/govuk-frontend/govuk/all";
 


### PR DESCRIPTION
This avoid having to add `class="govuk-link"` to every single link in the app.

Before:
<img width="1131" alt="Screenshot 2022-03-25 at 08 59 27" src="https://user-images.githubusercontent.com/687910/160089070-4e61c6be-fadd-457d-b189-dd61681a9842.png">

After:
<img width="1044" alt="Screenshot 2022-03-25 at 08 59 59" src="https://user-images.githubusercontent.com/687910/160089146-aad07237-7dad-4cb6-abc0-b6c5096e4654.png">

