### PR TITLE
Page titles rewrite for easier read in browser windows and GA

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Page not found - Criminal Justice System Scorecards</title>
+    <title>Page not found - Criminal Justice System Scorecards - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/src/404.html
+++ b/src/404.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>GOV.UK - Criminal Justice System Scorecards - Page not found</title>
+    <title>Page not found - Criminal Justice System Scorecards</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 
@@ -26,7 +26,9 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-XY07YLK2SE"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
+
+        function gtag () {dataLayer.push(arguments);}
+
         gtag('js', new Date());
 
         gtag('config', 'G-XY07YLK2SE');
@@ -69,19 +71,20 @@
 </header>
 
 <div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Page not found</h1>
-        <p class="govuk-body">
-          If you typed the web address, check it is correct.
-        </p>
-        <p class="govuk-body">
-          If you pasted the web address, check you copied the entire address.
-        </p>
-      </div>
-    </div>
-  </main>
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">Page not found</h1>
+                <p class="govuk-body">
+                    If you typed the web address, check it is correct.
+                    <br><br>
+                    If you pasted the web address, check you copied the entire address.
+                    <br><br>
+                    <a href="/">Return to the home page</a>
+                </p>
+            </div>
+        </div>
+    </main>
 </div>
 
 <footer class="govuk-footer " role="contentinfo">

--- a/src/50x.html
+++ b/src/50x.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>GOV.UK - Criminal Justice System Scorecards - Server error</title>
+    <title>Server error - Criminal Justice System Scorecards</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/src/50x.html
+++ b/src/50x.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Server error - Criminal Justice System Scorecards</title>
+    <title>Server error - Criminal Justice System Scorecards - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -4,7 +4,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>GOV.UK - Criminal Justice System Scorecards - Accessibility</title>
+    <title>Accessibility statement - Criminal Justice System Scorecards</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -4,7 +4,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Accessibility statement - Criminal Justice System Scorecards</title>
+    <title>Accessibility statement - Criminal Justice System Scorecards - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
 <head>
     <meta charset="utf-8">
-    <title>Dashboards - Criminal Justice System Scorecards</title>
+    <title>Criminal Justice System Scorecards - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
 <head>
     <meta charset="utf-8">
-    <title>GOV.UK - Criminal Justice System Scorecards</title>
+    <title>Dashboards - Criminal Justice System Scorecards</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 
@@ -32,18 +32,13 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-XY07YLK2SE"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
 
-        gtag('config', 'G-XY07YLK2SE');
     </script>
 </head>
 
-<body class="govuk-template__body ">
+<body class="govuk-template__body">
 <script>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-
 </script>
 
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>

--- a/src/index.html
+++ b/src/index.html
@@ -32,11 +32,15 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-XY07YLK2SE"></script>
     <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag () {dataLayer.push(arguments);}
 
+        gtag('js', new Date());
+        gtag('config', 'G-XY07YLK2SE');
     </script>
 </head>
 
-<body class="govuk-template__body">
+<body class="govuk-template__body ">
 <script>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>


### PR DESCRIPTION
Page titles are currently unhelpful when viewed in browser tabs and search engines due to the change in page name occurring at the end of the title string.

This update brings the name of the page to the start of the title string, giving users a visual aid to determine which page they are on. It also aids greatly when pages become ranked in search engines and for reporting in analytics software.